### PR TITLE
Change mastodon.py to Mastodonplus.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 diffusers < 0.7, >= 0.6
 transformers
-Mastodonplus.py
+Mastodonplus.py >= 1.5.5, < 2.0
 ftfy
 spacy
 pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 diffusers < 0.7, >= 0.6
 transformers
-mastodon.py == 1.5.1
+Mastodonplus.py
 ftfy
 spacy
 pillow


### PR DESCRIPTION
Mastodonplus.py is well maintained, compatible fork of mastodon.py.